### PR TITLE
Make directories more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ This is a list of all the options available, expected type, and default value.
 | `NOIRE_DATA_DIR`       | string        | "./data" (relative to executable) | Directory where application will store data                      |
 | `NOIRE_POSTS_PER_PAGE` | Natural       | 25                                | Maximum amount of posts allowed to be displayed on a single page |
 | `NOIRE_HOSTNAME`       | string        | localhost                         | A host name used in Atom feed links, including port if need be   |
+| `NOIRE_STATIC_DIR`     | string        | "./static"(relative to executable)| Path to static files directory                                   |
+| `NOIRE_POSTS_DIR`      | string        | "$NOIRE_DATA_DIR/posts"           | Path to posts directory (where .md files are stored)             |
+| `NOIRE_CACHE_DIR`      | string        | "$NOIRE_DATA_DIR/cache"           | Path to cache directory (noire needs write permissions there)    |
 
 > Note: When setting `NOIRE_DATA_DIR`, make sure user running the application has read and write permissions for this directory
 

--- a/noire.nimble
+++ b/noire.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Crystal Melting Dot"
 description   = "A minimalist blogging solution"
 license       = "MIT"

--- a/src/app.nim
+++ b/src/app.nim
@@ -10,6 +10,8 @@ import ./core/envConf
 
 
 addHandler(newConsoleLogger(fmtStr="[$datetime] - $levelname: "))
+
+when defined(filelog):
 addHandler(newRollingFileLogger("rolling.log", fmtStr="[$datetime] - $levelname: "))
 
 

--- a/src/app.nim
+++ b/src/app.nim
@@ -1,4 +1,3 @@
-import os
 import logging
 
 import prologue
@@ -12,7 +11,7 @@ import ./core/envConf
 addHandler(newConsoleLogger(fmtStr="[$datetime] - $levelname: "))
 
 when defined(filelog):
-addHandler(newRollingFileLogger("rolling.log", fmtStr="[$datetime] - $levelname: "))
+  addHandler(newRollingFileLogger("rolling.log", fmtStr="[$datetime] - $levelname: "))
 
 
 proc readConfig(): Settings =
@@ -28,6 +27,6 @@ proc readConfig(): Settings =
 
 proc noireMain*() =
   var app = newApp(settings = readConfig())
-  app.use staticFilesMiddleware(getAppDir() / "static")
+  app.use staticFilesMiddleware(getStaticDir())
   app.mountRoutes()
   app.run()

--- a/src/core/envConf.nim
+++ b/src/core/envConf.nim
@@ -29,3 +29,12 @@ proc getAppPostsPerPage*(): Natural =
 
 proc getAppHostName*(): string =
   getEnv("NOIRE_HOSTNAME", "localhost")
+
+proc getStaticDir*(): string =
+  getEnv("NOIRE_STATIC_DIR", getAppDir() / "static")
+
+proc getPostsDir*(): string {.inline.} =
+  getEnv("NOIRE_POSTS_DIR", getAppDataDir() / "posts")
+
+proc getCacheDir*(): string {.inline.} =
+  getEnv("NOIRE_CACHE_DIR", getAppDataDir() / "cache")

--- a/src/core/postindexer.nim
+++ b/src/core/postindexer.nim
@@ -1,4 +1,4 @@
-import os
+import os except getCacheDir
 import times
 import heapqueue
 import strutils
@@ -40,17 +40,6 @@ type
     score*: float  ## How relevant is result 
   IndexerData* = tuple[posts: seq[Post], totalPages: Natural]
 
-
-proc getDataDir*(): string {.inline.} =
-  result = getAppDataDir()
-
-
-proc getPostsDir*(): string {.inline.} =
-  getDataDir() / "posts"
-
-
-proc getCacheDir*(): string {.inline.} =
-  getDataDir() / "cache"
 
 
 proc `<`*(a,b: Post): bool =

--- a/src/middleware/static.nim
+++ b/src/middleware/static.nim
@@ -8,7 +8,7 @@ import std/strutils
 
 import prologue
 
-from ../core/postindexer import getPostsDir
+import ../core/envConf
 from ../core/util import walkVisible
 
 proc staticFilesMiddleware*(staticPath: string): HandlerAsync =
@@ -16,13 +16,13 @@ proc staticFilesMiddleware*(staticPath: string): HandlerAsync =
     let path = ctx.request.path
 
     # First check user resource
-    let user_res = getPostsDir() / path
+    let userRes = getPostsDir() / path
     for i in walkVisible(getPostsDir()):
-      if cmpPaths(i, user_res) == 0:
-        await ctx.staticFileResponse(user_res, "")
+      if cmpPaths(i, userRes) == 0:
+        await ctx.staticFileResponse(userRes, "")
     
     # Then fallback to common static dir
-    let common_res =  staticPath / path
-    if common_res.fileExists:
-      await ctx.staticFileResponse(common_res, "")
+    let commonRes =  staticPath / path
+    if commonRes.fileExists:
+      await ctx.staticFileResponse(commonRes, "")
     await ctx.switch

--- a/src/routes/common/components.nim
+++ b/src/routes/common/components.nim
@@ -3,6 +3,7 @@ import strutils
 import uri
 
 import ../../core/postindexer
+import ../../core/envConf
 
 
 type

--- a/src/routes/read.nim
+++ b/src/routes/read.nim
@@ -7,6 +7,7 @@ import prologue
 import ../render/page
 import ./common/components
 import ../core/postindexer
+import ../core/envConf
 
 
 proc readRoute*(ctx: Context) {.async.} =


### PR DESCRIPTION
Now there are a couple more env variables to control the app's directories more flexibly:
- `NOIRE_STATIC_DIR` 
- `NOIRE_POSTS_DIR`
- `NOIRE_CACHE_DIR`

Guess the names a pretty self-explanatory, if not, consult the readme for more detail.

The change should be backwards compatible, as far as I can judge.

closes #1 